### PR TITLE
Fix the CERN logo URL in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pytest .
 
 |||
 |-|-|
-|<a href="https://home.cern"><img src="https://design-guidelines.web.cern.ch/sites/design-guidelines.web.cern.ch/files/u6/CERN-logo.jpg" width="64"></a>|Made at [CERN](https://home.cern)<br>[Take part!](https://careers.cern/)|
+|<a href="https://home.cern"><img src="https://raw.githubusercontent.com/indico/assets/master/cern_badge.png" width="64"></a>|Made at [CERN](https://home.cern)<br>[Take part!](https://careers.cern/)|
 |||
 
 > ### Note


### PR DESCRIPTION
Fix by using the CERN logo asset from indico.

(Also a chance to say hello!)